### PR TITLE
Fix typo in component rendering description

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ bool
 
 </td>
 <td align="left"><code>True</code></td>
-<td align="left">If False, component will not render be rendered in the Blocks context. Should be used if the intention is to assign event listeners now but render the component later.</td>
+<td align="left">If False, component will not be rendered in the Blocks context. Should be used if the intention is to assign event listeners now but render the component later.</td>
 </tr>
 
 <tr>


### PR DESCRIPTION
Corrected a grammatical error in the documentation where "component will not render be rendered" was updated to "component will not be rendered." This improves the clarity and readability of the documentation.